### PR TITLE
prepare release v1.0.5 -> v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [1.0.6] - 2026-06-29
+### Added
+
+### Changed
+
+### Fixed
+- remove unsupported symbolic alleles when using bcftools consensus (currently supported: <DEL>, <*>, <NON_REF>)
+
+### Removed
+
 ## [1.0.5] - 2026-04-22
 ### Added
 - paper citation

--- a/nextflow.config
+++ b/nextflow.config
@@ -166,7 +166,7 @@ manifest {
     description     = 'Reference based virus assembly with automatic reference selection from ONT reads.'
     mainScript      = 'main.nf'
     nextflowVersion = '>=23.04.2'
-    version         = 'v1.0.5'
+    version         = 'v1.0.6'
 }
 
 dockerUser = 'oprgroup'


### PR DESCRIPTION
Fixed: remove unsupported symbolic alleles when using bcftools consensus (PR [#15](https://github.com/opr-group-bnitm/vimop/issues/15))